### PR TITLE
給料の表記を「233,800円」というように適切な場所にカンマが入るよう変更

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -168,7 +168,10 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span
+                        th:utext="${#numbers.formatInteger(employee.salary,1,'COMMA')  + '円'}"
+                        >400000円</span
+                      >
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
従業員詳細画面を上記のように変更しました。レビューよろしくお願いいたします。